### PR TITLE
Make agent count, cpu, mem customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ module "airplane_agent" {
 | [aws_iam_role.agent_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.agent_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.default_run_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_security_group.agent_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
@@ -54,12 +53,15 @@ module "airplane_agent" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_team_id"></a> [team\_id](#input\_team\_id) | Airplane team ID - retrieve via `airplane auth info`. | `string` | n/a | yes |
+| <a name="input_agent_cpu"></a> [agent\_cpu](#input\_agent\_cpu) | CPU per agent, in vCPU units | `number` | `256` | no |
 | <a name="input_agent_labels"></a> [agent\_labels](#input\_agent\_labels) | Map of label key/values to attach to agents. Labels can be used to constrain where tasks execute. | `map(string)` | <pre>{<br>  "ecs": "true"<br>}</pre> | no |
+| <a name="input_agent_mem"></a> [agent\_mem](#input\_agent\_mem) | Memory per agent, in megabytes | `number` | `512` | no |
 | <a name="input_api_host"></a> [api\_host](#input\_api\_host) | For development purposes. | `string` | `"https://api.airplane.dev"` | no |
 | <a name="input_api_token"></a> [api\_token](#input\_api\_token) | Airplane API key - generate one via `airplane apikeys create`. EIther this or API Token Secret must be set | `string` | `""` | no |
 | <a name="input_api_token_secret_arn"></a> [api\_token\_secret\_arn](#input\_api\_token\_secret\_arn) | ARN of API Token stored in AWS secret. Either this or API Token must be set. | `string` | `""` | no |
 | <a name="input_api_token_secret_kms_key_arn"></a> [api\_token\_secret\_kms\_key\_arn](#input\_api\_token\_secret\_kms\_key\_arn) | ARN of customer-managed KMS key, if any, used to encrypt API Token Secret. | `string` | `""` | no |
 | <a name="input_cluster_arn"></a> [cluster\_arn](#input\_cluster\_arn) | Your ECS cluster ARN. Leave blank to create a new cluster. | `string` | `""` | no |
+| <a name="input_num_agents"></a> [num\_agents](#input\_num\_agents) | Number of agent instances to run | `number` | `3` | no |
 | <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Name to assign to ECS service | `string` | `"airplane-agent"` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | List of subnet IDs for ECS service | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | AWS tags to attach to resources | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -188,8 +188,8 @@ resource "aws_ecs_task_definition" "agent_task_def" {
       }
     }
   ])
-  cpu = 256
-  memory = 512
+  cpu = var.agent_cpu
+  memory = var.agent_mem
   network_mode = "awsvpc"
   task_role_arn = aws_iam_role.agent_role.arn
   execution_role_arn = aws_iam_role.agent_execution_role.arn
@@ -205,7 +205,7 @@ resource "aws_ecs_task_definition" "agent_task_def" {
 resource "aws_ecs_service" "agent_service" {
   name = var.service_name
   cluster = var.cluster_arn == "" ? aws_ecs_cluster.cluster[0].arn : var.cluster_arn
-  desired_count = 3
+  desired_count = var.num_agents
   launch_type = "FARGATE"
   network_configuration {
     assign_public_ip = true

--- a/variables.tf
+++ b/variables.tf
@@ -42,6 +42,24 @@ variable "agent_labels" {
   default     = {ecs: "true"}
 }
 
+variable "agent_cpu" {
+  type = number
+  description = "CPU per agent, in vCPU units"
+  default = 256
+}
+
+variable "agent_mem" {
+  type = number
+  description = "Memory per agent, in megabytes"
+  default = 512
+}
+
+variable "num_agents" {
+  type =  number
+  description = "Number of agent instances to run"
+  default = 3
+}
+
 variable "service_name" {
   type = string
   description = "Name to assign to ECS service"


### PR DESCRIPTION
Resolves https://linear.app/airplane/issue/AIR-2875/add-ability-to-customize-cpumemnum-agents-to-tf-modules