### PR TITLE
Switch to Artifact Registry image

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -161,13 +161,14 @@ resource "aws_ecs_task_definition" "agent_task_def" {
   container_definitions = jsonencode([
     {
       name  = "airplane-agent"
-      image = "airplanedev/agent:1"
+      image = "us-docker.pkg.dev/airplane-prod/public/agent:1"
       environment = [
         { name = "AP_API_HOST", value = var.api_host },
         { name = "AP_API_TOKEN", value = var.api_token },
         { name = "AP_API_TOKEN_SECRET_ARN", value = var.api_token_secret_arn },
         { name = "AP_AWS_REGION", value = data.aws_region.current.name },
         { name = "AP_AUTO_UPGRADE", value = "true" },
+        { name = "AP_AGENT_IMAGE", value = "us-docker.pkg.dev/airplane-prod/public/agent:1" },
         { name = "AP_DEFAULT_CPU", value = var.default_task_cpu },
         { name = "AP_DEFAULT_MEMORY", value = var.default_task_memory },
         { name = "AP_DRIVER", value = "ecs" },


### PR DESCRIPTION
This PR switches the ECS module to use the agent image hosted on GCP Artifact Registry. This avoids issues with anonymous pull rate limiting from DockerHub.

Once merged, I'll publish a patch release (`0.2.3`).

cc @joshma 