### PR TITLE
Handle security groups and VPCs/subnets better

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,13 @@ module "airplane_agent" {
 | <a name="input_default_task_memory"></a> [default\_task\_memory](#input\_default\_task\_memory) | Default memory for tasks (e.g. 500Mi or 2Gi) | `string` | `"1Gi"` | no |
 | <a name="input_num_agents"></a> [num\_agents](#input\_num\_agents) | Number of agent instances to run | `number` | `3` | no |
 | <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Name to assign to ECS service | `string` | `"airplane-agent"` | no |
-| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | List of subnet IDs for ECS service. | `list(string)` | `[]` | no |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | List of subnet IDs for ECS service. All subnets must be from the same VPC. | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | AWS tags to attach to resources | `map(string)` | `{}` | no |
-| <a name="input_vpc_security_group_ids"></a> [vpc\_security\_group\_ids](#input\_vpc\_security\_group\_ids) | List of security group IDs to use. If not set, a new security group is created for each of the provided subnet IDs. | `list(string)` | `[]` | no |
+| <a name="input_vpc_security_group_ids"></a> [vpc\_security\_group\_ids](#input\_vpc\_security\_group\_ids) | List of security group IDs to use. If not set, a new security group is created for the VPC containing the provided subnets. | `list(string)` | `[]` | no |
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_agent_security_group_ids"></a> [agent\_security\_group\_ids](#output\_agent\_security\_group\_ids) | IDs of created security groups, if any |
 <!-- END_TF_DOCS -->

--- a/main.tf
+++ b/main.tf
@@ -219,7 +219,7 @@ resource "aws_ecs_service" "agent_service" {
   launch_type   = "FARGATE"
   network_configuration {
     assign_public_ip = true
-    security_groups  = length(var.vpc_security_group_ids) > 0 ? var.vpc_security_group_ids : (length(module.agent_security_group) > 0 ? [module.agent_security_group[0].security_group_id] : [])
+    security_groups  = length(var.vpc_security_group_ids) > 0 ? join(",", var.vpc_security_group_ids) : join(",", [for sg in module.agent_security_group : sg.security_group_id])
     subnets          = var.subnet_ids
   }
   task_definition = aws_ecs_task_definition.agent_task_def.arn

--- a/main.tf
+++ b/main.tf
@@ -8,12 +8,16 @@ resource "aws_ecs_cluster" "cluster" {
   count = var.cluster_arn == "" ? 1 : 0
 }
 
+data "aws_subnet" "selected" {
+  id = var.subnet_ids[0]
+}
+
 module "agent_security_group" {
   source = "terraform-aws-modules/security-group/aws"
 
   name        = "airplane-agent"
   description = "Security group for Airplane agent"
-  vpc_id      = var.vpc_id
+  vpc_id      = data.aws_subnet.selected.vpc_id
 
   egress_rules = ["all-all"]
 

--- a/main.tf
+++ b/main.tf
@@ -9,18 +9,18 @@ resource "aws_ecs_cluster" "cluster" {
 }
 
 data "aws_subnet" "selected" {
-  count = length(var.subnet_ids) > 0 ? 1 : 0
-  id = var.subnet_ids[0]
+  count = length(var.subnet_ids)
+  id = var.subnet_ids[count.index]
 }
 
 module "agent_security_group" {
   source = "terraform-aws-modules/security-group/aws"
 
-  count = length(data.aws_subnet.selected) > 0 && length(var.vpc_security_group_ids) == 0 ? 1 : 0
+  count = length(var.vpc_security_group_ids) > 0 ? 0 : length(data.aws_subnet.selected)
 
   name        = "airplane-agent"
   description = "Security group for Airplane agent"
-  vpc_id      = data.aws_subnet.selected[0].vpc_id
+  vpc_id      = data.aws_subnet.selected[count.index].vpc_id
 
   egress_rules = ["all-all"]
 
@@ -182,7 +182,7 @@ resource "aws_ecs_task_definition" "agent_task_def" {
         { name = "AP_ECS_CLUSTER", value = var.cluster_arn == "" ? aws_ecs_cluster.cluster[0].arn : var.cluster_arn },
         { name = "AP_ECS_EXECUTION_ROLE", value = aws_iam_role.default_run_role.arn },
         { name = "AP_ECS_LOG_GROUP", value = aws_cloudwatch_log_group.run_log_group.name },
-        { name = "AP_ECS_SECURITY_GROUPS", value = length(var.vpc_security_group_ids) > 0 ? join(",", var.vpc_security_group_ids) : (length(module.agent_security_group) > 0 ? module.agent_security_group[0].security_group_id : "") },
+        { name = "AP_ECS_SECURITY_GROUPS", value = length(var.vpc_security_group_ids) > 0 ? join(",", var.vpc_security_group_ids) : join(",", [for sg in module.agent_security_group : sg.security_group_id]) },
         { name = "AP_ECS_SUBNETS", value = join(",", var.subnet_ids) },
         { name = "AP_LABELS", value = join(",", [for key, value in var.agent_labels : "${key}:${value}"]) },
         { name = "AP_PARALLELISM", value = "50" },

--- a/variables.tf
+++ b/variables.tf
@@ -77,9 +77,3 @@ variable "subnet_ids" {
   description = "List of subnet IDs for ECS service"
   default = []
 }
-
-variable "vpc_id" {
-  type = string
-  description = "VPC to deploy to, should match subnet IDs"
-  default = ""
-}

--- a/variables.tf
+++ b/variables.tf
@@ -86,12 +86,12 @@ variable "tags" {
 
 variable "subnet_ids" {
   type        = list(string)
-  description = "List of subnet IDs for ECS service"
+  description = "List of subnet IDs for ECS service. Will create a security group for each one."
   default     = []
 }
 
 variable "vpc_security_group_ids" {
   type        = list(string)
-  description = "List of security group IDs to use. If not set, a new security group is created for the provided subnet IDs."
+  description = "List of security group IDs to use. If not set, a new security group is created for each of the provided subnet IDs."
   default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -89,3 +89,9 @@ variable "subnet_ids" {
   description = "List of subnet IDs for ECS service"
   default     = []
 }
+
+variable "vpc_security_group_ids" {
+  type        = list(string)
+  description = "List of security group IDs to use. If not set, a new security group is created for the provided subnet IDs."
+  default     = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -86,7 +86,7 @@ variable "tags" {
 
 variable "subnet_ids" {
   type        = list(string)
-  description = "List of subnet IDs for ECS service. Will create a security group for each one."
+  description = "List of subnet IDs for ECS service."
   default     = []
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -86,12 +86,12 @@ variable "tags" {
 
 variable "subnet_ids" {
   type        = list(string)
-  description = "List of subnet IDs for ECS service."
+  description = "List of subnet IDs for ECS service. All subnets must be from the same VPC."
   default     = []
 }
 
 variable "vpc_security_group_ids" {
   type        = list(string)
-  description = "List of security group IDs to use. If not set, a new security group is created for each of the provided subnet IDs."
+  description = "List of security group IDs to use. If not set, a new security group is created for the VPC containing the provided subnets."
   default     = []
 }


### PR DESCRIPTION
Removes the `vpc_id` var, adds the `vpc_security_group_ids` var, and changes the logic to the following:
* If `vpc_security_group_ids` is non-empty, doesn't create any security groups, but uses the provided ones instead
* If `vpc_security_group_ids` is empty, but `subnet_ids` is non-empty, creates a security group for each subnet's VPC, and uses that as the list of security groups to pass to the agent
* If both are empty, doesn't create any security groups

Tested by running `terraform plan` with all 3 of the above cases and checking that it looks reasonable.

---
cc @joshma 